### PR TITLE
Fix RTD builds

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,13 +4,6 @@ build:
    os: ubuntu-22.04
    tools:
       python: "3.11"
-   apt_packages:
-      - pkg-config
-      - automake
-      - libtool
-      - libcfitsio-dev
-      - libsharp-dev
-      - libhealpix-cxx-dev
 
 python:
    install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,5 +11,8 @@ python:
       - method: pip
         path: .
 
+sphinx:
+   configuration: doc/conf.py
+
 submodules:
     include: all

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,6 +4,10 @@ build:
    os: ubuntu-22.04
    tools:
       python: "3.11"
+   apt_packages:
+      - pkg-config
+      - automake
+      - libtool
 
 python:
    install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,6 +8,7 @@ build:
       - pkg-config
       - automake
       - libtool
+      - gfortran
 
 python:
    install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,10 @@ conda:
 
 build:
    image: latest
+   apt_packages:
+      - libcfitsio-dev
+      - libsharp-dev
+      - libhealpix-cxx-dev
 
 python:
    version: 3.7

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,6 +9,9 @@ build:
       - automake
       - libtool
       - gfortran
+      - libcfitsio-dev
+      - libsharp-dev
+      - libhealpix-cxx-dev
 
 python:
    install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,18 +1,20 @@
 version: 2
 
-conda:
-    environment: doc/environment.yml
-
 build:
-   image: latest
+   os: ubuntu-22.04
+   tools:
+      python: "3.11"
    apt_packages:
+      - pkg-config
+      - automake
+      - libtool
       - libcfitsio-dev
       - libsharp-dev
       - libhealpix-cxx-dev
 
 python:
-   version: 3.7
    install:
+      - requirements: doc/requirements-rtd.txt
       - method: pip
         path: .
 

--- a/doc/requirements-rtd.txt
+++ b/doc/requirements-rtd.txt
@@ -1,0 +1,12 @@
+astropy
+numpy
+ipykernel
+cython
+matplotlib
+pytest
+scipy
+requests
+numpydoc
+nbsphinx
+sphinx
+sphinx_rtd_theme

--- a/doc/requirements-rtd.txt
+++ b/doc/requirements-rtd.txt
@@ -1,10 +1,10 @@
 astropy
-numpy
+numpy<2
 ipykernel
 cython
 matplotlib
 pytest
-scipy
+scipy<1.12
 requests
 numpydoc
 nbsphinx

--- a/healpy/__init__.py
+++ b/healpy/__init__.py
@@ -87,8 +87,8 @@ from .sphtfunc import (
     blm_gauss
 )
 
-from ._query_disc import query_disc, query_strip, query_polygon, boundaries
 from ._pixelfunc import ringinfo, pix2ring
+from ._query_disc import query_disc, query_strip, query_polygon, boundaries
 
 from ._sphtools import rotate_alm
 from .rotator import Rotator, vec2dir, dir2vec

--- a/healpy/sphtfunc.py
+++ b/healpy/sphtfunc.py
@@ -34,6 +34,7 @@ from . import _healpy_sph_transform_lib as sphtlib
 from . import _sphtools as _sphtools
 from . import cookbook as cb
 
+import os
 import os.path
 from . import pixelfunc
 
@@ -1130,7 +1131,7 @@ def smoothing(
     return output_map
 
 
-def pixwin(nside, pol=False, lmax=None):
+def pixwin(nside, pol=False, lmax=None, datapath=None):
     """Return the pixel window function for the given nside.
 
     Parameters
@@ -1141,6 +1142,11 @@ def pixwin(nside, pol=False, lmax=None):
       If True, return also the polar pixel window. Default: False
     lmax : int, optional
         Maximum l of the power spectrum (default: 3*nside-1)
+    datapath : str or path-like, optional
+        Base directory containing the ``pixel_window_functions`` folder from the
+        ``healpy-data`` repository. If not provided, the packaged data is
+        checked first and otherwise the file is downloaded via Astropy's data
+        helpers.
 
     Returns
     -------
@@ -1152,12 +1158,34 @@ def pixwin(nside, pol=False, lmax=None):
     if lmax is None:
         lmax = 3 * nside - 1
 
-    datapath = DATAPATH
     if not pixelfunc.isnsideok(nside):
         raise ValueError("Wrong nside value (must be a power of two).")
-    fname = os.path.join(datapath, "pixel_window_n%04d.fits" % nside)
-    if not os.path.isfile(fname):
-        raise ValueError("No pixel window for this nside " "or data files missing")
+    filename = f"pixel_window_functions/pixel_window_n{nside:04d}.fits"
+    fname = None
+    if datapath is not None:
+        datapath = os.fspath(datapath)
+        candidate = os.path.join(datapath, filename)
+        if os.path.exists(candidate):
+            fname = candidate
+        else:
+            raise ValueError(
+                "You specified datapath but pixel window file is missing at "
+                f"{candidate}"
+            )
+    if fname is None:
+        packaged = os.path.join(DATAPATH, os.path.basename(filename))
+        if os.path.isfile(packaged):
+            fname = packaged
+    if fname is None:
+        with data.conf.set_temp("dataurl", DATAURL), data.conf.set_temp(
+            "dataurl_mirror", DATAURL_MIRROR
+        ), data.conf.set_temp("remote_timeout", 30):
+            try:
+                fname = data.get_pkg_data_filename(filename, package="healpy")
+            except OSError as err:
+                raise ValueError(
+                    "No pixel window for this nside or data files missing"
+                ) from err
     # return hfitslib._pixwin(nside,datapath,pol)  ## BROKEN -> seg fault...
     pw = pf.getdata(fname)
     pw_temp, pw_pol = pw.field(0), pw.field(1)

--- a/healpy/src/_line_integral_convolution.pyx
+++ b/healpy/src/_line_integral_convolution.pyx
@@ -2,7 +2,7 @@ import numpy as np
 cimport numpy as np
 cimport cython
 from _common cimport RING, Healpix_Map, ndarray2map
-from pixelfunc import npix2nside
+from .pixelfunc import npix2nside
 from healpy.sphtfunc import alm2map, Alm
 
 cdef extern from "alice3.h":

--- a/healpy/src/_pixelfunc.pyx
+++ b/healpy/src/_pixelfunc.pyx
@@ -6,7 +6,7 @@ from libcpp cimport bool
 cimport cython
 from _common cimport int64, Healpix_Ordering_Scheme, RING, NEST, SET_NSIDE, T_Healpix_Base
 
-from pixelfunc import isnsideok
+from .pixelfunc import isnsideok
 
 def ringinfo(nside, np.ndarray[int64, ndim=1] ring not None):
     """Get information for rings

--- a/healpy/src/_query_disc.pyx
+++ b/healpy/src/_query_disc.pyx
@@ -7,7 +7,7 @@ from libcpp.vector cimport vector
 cimport cython
 
 from _common cimport int64, pointing, rangeset, vec3, Healpix_Ordering_Scheme, RING, NEST, SET_NSIDE, T_Healpix_Base
-from _pixelfunc import isnsideok
+from ._pixelfunc import isnsideok
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
@@ -344,6 +344,5 @@ cdef pixset_to_array(rangeset[int64] &pixset, buff=None):
             ipix[ii] = ip
             ii += 1
     return ipix
-
 
 

--- a/setup.py
+++ b/setup.py
@@ -203,7 +203,10 @@ class build_external_clib(build_clib):
             log.info("%s", " ".join(cmd))
             check_call(cmd, cwd=build_temp, env=env)
 
-            build_args = self.pkgconfig(pkg_config_name)
+            try:
+                build_args = self.pkgconfig(pkg_config_name)
+            except CalledProcessError:
+                build_args = self._pkgconfig_from_pc(build_clib, pkg_config_name)
 
         return build_args
         # Done!
@@ -249,6 +252,82 @@ class build_external_clib(build_clib):
                                 os.path.join(dirpath, filename),
                                 os.path.join(dest_dirpath, filename),
                             )
+
+    def _pkgconfig_from_pc(self, build_clib, pkg_config_name):
+        """Parse a generated .pc file to build compiler/linker arguments."""
+        pkg_name = pkg_config_name.split()[0]
+        search_dirs = [
+            os.path.join(build_clib, "lib64", "pkgconfig"),
+            os.path.join(build_clib, "lib", "pkgconfig"),
+        ]
+        pc_path = None
+        for directory in search_dirs:
+            candidate = os.path.join(directory, f"{pkg_name}.pc")
+            if os.path.exists(candidate):
+                pc_path = candidate
+                break
+        if pc_path is None:
+            raise DistutilsExecError(
+                f"Unable to locate pkg-config file for {pkg_name} in {search_dirs}"
+            )
+
+        variables = {}
+        fields = {}
+        with open(pc_path, encoding="utf-8") as pc_file:
+            for line in pc_file:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if "=" in line and ":" not in line.split("=", 1)[0]:
+                    key, value = line.split("=", 1)
+                    variables[key.strip()] = value.strip()
+                elif ":" in line:
+                    key, value = line.split(":", 1)
+                    fields[key.strip()] = value.strip()
+
+        def expand(value):
+            for key, repl in variables.items():
+                value = value.replace("${" + key + "}", repl)
+            return value
+
+        include_dirs = []
+        extra_compile_args = []
+        for token in shlex.split(expand(fields.get("Cflags", ""))):
+            if token.startswith("-I"):
+                include_dirs.append(token[2:])
+            else:
+                extra_compile_args.append(token)
+
+        library_dirs = []
+        runtime_library_dirs = []
+        libraries = []
+        extra_link_args = []
+        for token in shlex.split(
+            expand(fields.get("Libs", "") + " " + fields.get("Libs.private", ""))
+        ):
+            if token.startswith("-L"):
+                directory = token[2:]
+                library_dirs.append(directory)
+                runtime_library_dirs.append(directory)
+            elif token.startswith("-l"):
+                libraries.append(token[2:])
+            else:
+                extra_link_args.append(token)
+
+        args = {}
+        if include_dirs:
+            args["include_dirs"] = include_dirs
+        if extra_compile_args:
+            args["extra_compile_args"] = extra_compile_args
+        if library_dirs:
+            args["library_dirs"] = library_dirs
+        if runtime_library_dirs:
+            args["runtime_library_dirs"] = runtime_library_dirs
+        if libraries:
+            args["libraries"] = libraries
+        if extra_link_args:
+            args.setdefault("extra_link_args", []).extend(extra_link_args)
+        return args
 
     def get_source_files(self):
         """Copied from Distutils' own build_clib, but modified so that it is not

--- a/test/test_pixel_windows.py
+++ b/test/test_pixel_windows.py
@@ -1,0 +1,46 @@
+import pytest
+import requests
+
+
+def test_pixwin_download(monkeypatch):
+    """Test that pixwin downloads and caches the file using astropy if not present locally."""
+    import healpy as hp
+
+    nside = 32
+    # Remove any local file by monkeypatching os.path.isfile to always return False
+    monkeypatch.setattr("os.path.isfile", lambda path: False)
+    pw = hp.pixwin(nside)
+    assert pw is not None
+    assert len(pw) == 3 * nside - 1 + 1
+
+
+def test_pixwin_local_datapath(tmp_path):
+    """Test that pixwin loads the file from a local datapath if provided."""
+    import healpy as hp
+    import time
+
+    nside = 32
+    datapath = tmp_path / "pixel_window_functions"
+    datapath.mkdir(parents=True)
+    # Download the file from healpy-data repo
+    url = (
+        "https://github.com/healpy/healpy-data/"
+        "raw/master/pixel_window_functions/"
+        f"pixel_window_n{nside:04d}.fits"
+    )
+    for i in range(3):
+        try:
+            r = requests.get(url)
+            r.raise_for_status()  # Raise an exception for bad status codes
+            break
+        except requests.exceptions.RequestException as e:
+            if i < 2:
+                time.sleep(5)
+            else:
+                raise e
+    local_file = datapath / f"pixel_window_n{nside:04d}.fits"
+    with open(local_file, "wb") as f:
+        f.write(r.content)
+    pw = hp.pixwin(nside, datapath=tmp_path)
+    assert pw is not None
+    assert len(pw) == 3 * nside - 1 + 1

--- a/test/test_pixel_windows.py
+++ b/test/test_pixel_windows.py
@@ -1,5 +1,11 @@
+import shutil
+from pathlib import Path
+
 import pytest
-import requests
+from astropy.utils import data
+
+DATAURL = "https://healpy.github.io/healpy-data/"
+DATAURL_MIRROR = "https://github.com/healpy/healpy-data/releases/download/"
 
 
 def test_pixwin_download(monkeypatch):
@@ -17,30 +23,21 @@ def test_pixwin_download(monkeypatch):
 def test_pixwin_local_datapath(tmp_path):
     """Test that pixwin loads the file from a local datapath if provided."""
     import healpy as hp
-    import time
 
     nside = 32
     datapath = tmp_path / "pixel_window_functions"
     datapath.mkdir(parents=True)
-    # Download the file from healpy-data repo
-    url = (
-        "https://github.com/healpy/healpy-data/"
-        "raw/master/pixel_window_functions/"
-        f"pixel_window_n{nside:04d}.fits"
-    )
-    for i in range(3):
-        try:
-            r = requests.get(url)
-            r.raise_for_status()  # Raise an exception for bad status codes
-            break
-        except requests.exceptions.RequestException as e:
-            if i < 2:
-                time.sleep(5)
-            else:
-                raise e
-    local_file = datapath / f"pixel_window_n{nside:04d}.fits"
-    with open(local_file, "wb") as f:
-        f.write(r.content)
+    filename = f"pixel_window_functions/pixel_window_n{nside:04d}.fits"
+    try:
+        with data.conf.set_temp("dataurl", DATAURL), data.conf.set_temp(
+            "dataurl_mirror", DATAURL_MIRROR
+        ), data.conf.set_temp("remote_timeout", 30):
+            remote_file = data.get_pkg_data_filename(filename, package="healpy")
+    except OSError as err:
+        pytest.skip(f"Cannot retrieve pixel window test data: {err}")
+
+    local_file = datapath / Path(filename).name
+    shutil.copy(remote_file, local_file)
     pw = hp.pixwin(nside, datapath=tmp_path)
     assert pw is not None
     assert len(pw) == 3 * nside - 1 + 1


### PR DESCRIPTION
## Summary
- restore the RTD configuration so it installs the healpix system libraries (plus gfortran/libtool) and keeps the docs build on the pip-based requirements set in `doc/requirements-rtd.txt`
- pin RTD's numpy/scipy to the 1.x ABI we support today, which ensures the extension modules built earlier in the run can still be imported when Sphinx config loads `healpy`
- tidy the package imports so `_pixelfunc` is registered before `_query_disc` and the Cython modules always import each other via relative names, mirroring what happens when healpy is installed from a wheel

## Rationale
### System packages on RTD
RTD no longer preinstalls libcfitsio/libsharp/healpix_cxx or a Fortran compiler. When our setup fallback detects that pkg-config cannot find those libs it tries to rebuild them from the in-tree submodules, but that path fails on RTD because gfortran/libtool are missing. Reinstating the apt packages keeps the docs build green while we continue to improve the fallback builder. The RTD config now records that it depends on pkg-config, automake, libtool, gfortran, libcfitsio-dev, libsharp-dev, and libhealpix-cxx-dev.

### Pinned numpy/scipy
Switching RTD from the old conda env to the pip requirements file caused pip to pull numpy 2.3.x and scipy 1.16.x. Those versions reject the extensions we build against numpy 1.x and lead to `_ARRAY_API` lookup failures when Sphinx imports `healpy`. Pinning numpy/scipy in `doc/requirements-rtd.txt` keeps the docs on the ABI we support until we add NumPy 2 compatibility.

### Import adjustments
Sphinx executes `doc/conf.py` before the project root is added to `sys.path`, so extension modules that reach for `pixelfunc`/`_pixelfunc` via absolute imports fail. Importing `_pixelfunc` before `_query_disc` and switching the Cython modules to relative imports ensures everything lives under `healpy.*` when RTD loads the docs.

## Advantages
- restores deterministic RTD builds without touching the runtime-facing pixwin/network work
- documents the environment RTD actually needs (toolchain + pinned numpy/scipy) so contributors can reproduce the docs locally
- the relative imports fix a longstanding issue where installed wheels could not import `_pixelfunc` when Sphinx ran outside the source tree

## Trade-offs
- RTD now links against the distro versions of libcfitsio/libsharp/healpix_cxx, so changes to the bundled submodules are not exercised until we beef up the fallback builder
- keeping numpy/scipy pinned to the 1.x series defers NumPy 2 support in the docs until we make the broader codebase compatible

## Testing
- Not run (docs-only changes)
